### PR TITLE
panel: fix build error

### DIFF
--- a/panel.cpp
+++ b/panel.cpp
@@ -168,14 +168,11 @@ Panel::Panel(QWidget *parent) : QMainWindow(parent)
     layerShell->setLayer(LayerShellQt::Window::Layer(layer.keyToValue("LayerTop")));
 
     // Panel position
-    const QString panelAnchors = "AnchorBottom|AnchorLeft|AnchorRight";
-    const auto anchorEnums = QMetaEnum::fromType<LayerShellQt::Window::Anchor>();
-    uint32_t anchors = 0;
-    const auto stringList = panelAnchors.split(QLatin1Char('|'));
-    for (const auto &value : stringList) {
-        anchors |= anchorEnums.keyToValue(qPrintable(value));
-    }
-    layerShell->setAnchors((LayerShellQt::Window::Anchors)anchors);
+    LayerShellQt::Window::Anchors anchors;
+    anchors.setFlag(LayerShellQt::Window::AnchorLeft);
+    anchors.setFlag(LayerShellQt::Window::AnchorBottom);
+    anchors.setFlag(LayerShellQt::Window::AnchorRight);
+    layerShell->setAnchors(anchors);
 
     const auto interactivity = QMetaEnum::fromType<LayerShellQt::Window::KeyboardInteractivity>();
     layerShell->setKeyboardInteractivity(LayerShellQt::Window::KeyboardInteractivity(


### PR DESCRIPTION
...with layer-shell-qt 6.5.0

In file included from /usr/include/x86_64-linux-gnu/qt6/QtCore/QMetaEnum:1, from ../panel.cpp:5: /usr/include/x86_64-linux-gnu/qt6/QtCore/qmetaobject.h: In instantiation of ‘static QMetaEnum QMetaEnum::fromType() [with T = LayerShellQt::Window::Anchor]’: ../panel.cpp:172:79:   required from here 172 |     const auto anchorEnums = QMetaEnum::fromType<LayerShellQt::Window::Anchor>(); |                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~ /usr/include/x86_64-linux-gnu/qt6/QtCore/qmetaobject.h:302:52: error: static assertion failed: QMetaEnum::fromType only works with enums declared as Q_ENUM, Q_ENUM_NS, Q_FLAG or Q_FLAG_NS 302 |         static_assert(QtPrivate::IsQEnumHelper<T>::Value, |                                                    ^~~~~

Fixes: #3